### PR TITLE
Identical endswith and empty endwith is the eos

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -93,9 +93,10 @@ async function lintBody(id) {
 function verifySection(section) {
   const body = pull_request.body;
   const sectionStart = body.indexOf(section.beginsWith) + section.beginsWith.length;
+  const sectionEnd = section.endsWith === "" ? section.length : body.indexOf(section.endsWith, sectionStart);
   let result = body.substring(
     sectionStart,
-    body.indexOf(section.endsWith, sectionStart)
+    sectionEnd
   );
   result = result.replace(new RegExp('\r', 'g'), '');
   result = result.replace(new RegExp('\n', 'g'), '');

--- a/lib/run.js
+++ b/lib/run.js
@@ -92,9 +92,10 @@ async function lintBody(id) {
 
 function verifySection(section) {
   const body = pull_request.body;
+  const sectionStart = body.indexOf(section.beginsWith) + section.beginsWith.length;
   let result = body.substring(
-    body.indexOf(section.beginsWith) + section.beginsWith.length,
-    body.indexOf(section.endsWith)
+    sectionStart,
+    body.indexOf(section.endsWith, sectionStart)
   );
   result = result.replace(new RegExp('\r', 'g'), '');
   result = result.replace(new RegExp('\n', 'g'), '');


### PR DESCRIPTION
I.e. if I want to have as little extra markup as possible

```
### First section

### Next section

### Last section
```

Now I can use "First section" as startsWith and "###" as endsWith, and "Next section" as startsWith and "###" as endsWidth, and "Last section" as startsWith and "" as the endsWith